### PR TITLE
[>= iOS 13] Avoid warnings for `-[UIApplication statusBarOrientation]` usage

### DIFF
--- a/SupportSDK.framework/Headers/ZDKUIUtil.h
+++ b/SupportSDK.framework/Headers/ZDKUIUtil.h
@@ -165,7 +165,10 @@ CGRectMakeCenteredInScreen(CGFloat width, CGFloat height)
 {
     CGRect screen = [UIScreen mainScreen].bounds;
 
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+    #pragma clang diagnostic pop
 
     CGRect rect;
 
@@ -221,7 +224,10 @@ CGCenterRectInRect(CGRect rect, CGRect inRect)
 CG_INLINE BOOL
 ZDKUIIsLandscape()
 {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+    #pragma clang diagnostic pop
     return UIInterfaceOrientationIsLandscape(orientation);
 }
 

--- a/SupportSDK.xcframework/ios-armv7_arm64/SupportSDK.framework/Headers/ZDKUIUtil.h
+++ b/SupportSDK.xcframework/ios-armv7_arm64/SupportSDK.framework/Headers/ZDKUIUtil.h
@@ -165,7 +165,10 @@ CGRectMakeCenteredInScreen(CGFloat width, CGFloat height)
 {
     CGRect screen = [UIScreen mainScreen].bounds;
 
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+    #pragma clang diagnostic pop
 
     CGRect rect;
 
@@ -221,7 +224,10 @@ CGCenterRectInRect(CGRect rect, CGRect inRect)
 CG_INLINE BOOL
 ZDKUIIsLandscape()
 {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+    #pragma clang diagnostic pop
     return UIInterfaceOrientationIsLandscape(orientation);
 }
 

--- a/SupportSDK.xcframework/ios-i386_x86_64-simulator/SupportSDK.framework/Headers/ZDKUIUtil.h
+++ b/SupportSDK.xcframework/ios-i386_x86_64-simulator/SupportSDK.framework/Headers/ZDKUIUtil.h
@@ -165,7 +165,10 @@ CGRectMakeCenteredInScreen(CGFloat width, CGFloat height)
 {
     CGRect screen = [UIScreen mainScreen].bounds;
 
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+    #pragma clang diagnostic pop
 
     CGRect rect;
 
@@ -221,7 +224,10 @@ CGCenterRectInRect(CGRect rect, CGRect inRect)
 CG_INLINE BOOL
 ZDKUIIsLandscape()
 {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+    #pragma clang diagnostic pop
     return UIInterfaceOrientationIsLandscape(orientation);
 }
 


### PR DESCRIPTION
**Description:**
Usage of `-[UIApplication statusBarOrientation]` is surfaced in inline C functions in the `ZDKUIUtil.h`. This is a stopgap to allow framework consumers to `import SupportSDK` when compiling with:

```
GCC_TREAT_WARNINGS_AS_ERRORS = YES
IPHONEOS_DEPLOYMENT_TARGET = 13.0
```

Long term, the usage of this API should be removed especially from publicly surfaced C funcs. 👍 