### PR TITLE
Add Swift Package Manager Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "ZendeskSupportSDK",
+    platforms: [
+        .iOS(.v10)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "ZendeskSupportSDK",
+            targets: ["ZendeskSupportSDK", "ZendeskSupportSDKBinaryPackage"])
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "ZendeskSupportSDK"
+        ),
+        .binaryTarget(
+            name: "ZendeskSupportSDKBinaryPackage",
+            path: "SupportSDK.xcframework"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -10,19 +10,14 @@ let package = Package(
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "ZendeskSupportSDK",
-            targets: ["ZendeskSupportSDK", "ZendeskSupportSDKBinaryPackage"])
+            targets: ["ZendeskSupportSDK"])
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .target(
-            name: "ZendeskSupportSDK"
-        ),
         .binaryTarget(
-            name: "ZendeskSupportSDKBinaryPackage",
+            name: "ZendeskSupportSDK",
             path: "SupportSDK.xcframework"
         )
     ]


### PR DESCRIPTION
Currently the build still fails with:

`Failed to build module 'SupportSDK' from its module interface; the compiler that produced it, 'Apple Swift version 5.2.4 (swiftlang-1103.0.32.9 clang-1103.0.32.53)', may have used features that aren't supported by this compiler, 'Apple Swift version 5.3 (swiftlang-1200.0.29.2 clang-1200.0.30.1)'`

This should be fixed by recompiling the .xcframework with Swift 5.3.