### PR TITLE
Unify artifact name and target name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,12 +23,12 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(
-            name: "ZendeskSupportSDK",
+            name: "SupportSDK",
             path: "SupportSDK.xcframework"
         ),
         .target(name: "ZendeskSupportSDKTargets",
                 dependencies: [
-                    .target(name: "ZendeskSupportSDK"),
+                    .target(name: "SupportSDK"),
                     .product(name: "ZendeskSupportProvidersSDK", package: "ZendeskSupportProvidersSDK"),
                     .product(name: "ZendeskMessagingSDK", package: "ZendeskMessagingSDK")
                 ],


### PR DESCRIPTION
Dependencies fail to install on Xcode 13.3 due to a mismatch between the binary target name and the artifact name. This PR unify both names.