### PR TITLE
Add clang ignore deprecations around UIScreen.main

### DIFF
--- a/SupportSDK.xcframework/ios-arm64/SupportSDK.framework/Headers/ZDKUIUtil.h
+++ b/SupportSDK.xcframework/ios-arm64/SupportSDK.framework/Headers/ZDKUIUtil.h
@@ -187,7 +187,10 @@ ZDKUIIsLandscape()
 CG_INLINE CGRect
 CGRectMakeCenteredInScreen(CGFloat width, CGFloat height)
 {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CGRect screen = [UIScreen mainScreen].bounds;
+    #pragma clang diagnostic pop
 
     Boolean isLandscape = ZDKUIIsLandscape();
 
@@ -243,7 +246,10 @@ CGCenterRectInRect(CGRect rect, CGRect inRect)
 CG_INLINE CGRect
 ZDKUIScreenFrame()
 {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CGSize screenSize = [UIScreen mainScreen].bounds.size;
+    #pragma clang diagnostic pop
 
     CGFloat width = screenSize.width;
     CGFloat height = screenSize.height;

--- a/SupportSDK.xcframework/ios-arm64_x86_64-simulator/SupportSDK.framework/Headers/ZDKUIUtil.h
+++ b/SupportSDK.xcframework/ios-arm64_x86_64-simulator/SupportSDK.framework/Headers/ZDKUIUtil.h
@@ -187,7 +187,10 @@ ZDKUIIsLandscape()
 CG_INLINE CGRect
 CGRectMakeCenteredInScreen(CGFloat width, CGFloat height)
 {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CGRect screen = [UIScreen mainScreen].bounds;
+    #pragma clang diagnostic pop
 
     Boolean isLandscape = ZDKUIIsLandscape();
 
@@ -243,7 +246,10 @@ CGCenterRectInRect(CGRect rect, CGRect inRect)
 CG_INLINE CGRect
 ZDKUIScreenFrame()
 {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CGSize screenSize = [UIScreen mainScreen].bounds.size;
+    #pragma clang diagnostic pop
 
     CGFloat width = screenSize.width;
     CGFloat height = screenSize.height;


### PR DESCRIPTION
This change is to silence deprecation warnings around `[UIScreen mainScreen]` in Xcode 26. This change is similar to the change made to silence warnings around `statusBarOrientation` back in version `6.0.0`.